### PR TITLE
optimize, remove safe math

### DIFF
--- a/contracts/adapter.sol
+++ b/contracts/adapter.sol
@@ -13,11 +13,11 @@ contract USDCAdapter is Initializable, AccessControlUpgradeable {
     IVault public vaultContract; // Vault Engine
     bytes32 public collateralType; // USDC Type USDC-A | USDT-A
     IERC20 public collateralContract; // usdc contract
-    uint public live; // Active Flag
+    uint256 public live; // Active Flag
 
     // -- EVENTS --
-    event USDCJoined(uint vaultId, address indexed owner, uint256 amount);
-    event USDCExited(uint vaultId, address indexed owner, uint256 amount);
+    event USDCJoined(uint256 vaultId, address indexed owner, uint256 amount);
+    event USDCExited(uint256 vaultId, address indexed owner, uint256 amount);
 
     // -- ERRORS --
     error NotLive(string error);
@@ -87,11 +87,11 @@ contract USDCAdapter is Initializable, AccessControlUpgradeable {
 contract xNGNAdapter is Initializable, AccessControlUpgradeable {
     IVault public vaultContract; // Vault Engine
     IxNGN public xNGN; // NGNx contract
-    uint public live; // Active Flag
+    uint256 public live; // Active Flag
 
     // -- EVENTS --
-    event xNGNJoined(uint vaultId, address indexed owner, uint256 amount);
-    event xNGNExited(uint vaultId, address indexed owner, uint256 amount);
+    event xNGNJoined(uint256 vaultId, address indexed owner, uint256 amount);
+    event xNGNExited(uint256 vaultId, address indexed owner, uint256 amount);
 
     // -- ERRORS --
     error NotLive(string error);

--- a/contracts/adapter.sol
+++ b/contracts/adapter.sol
@@ -42,7 +42,7 @@ contract USDCAdapter is Initializable, AccessControlUpgradeable {
         address owner,
         uint256 _vaultId
     ) external isLive {
-        if (amount <= 0) {
+        if (amount == 0) {
             revert ZeroAmount("Adapter/amount-is-zero");
         }
         // calls vault contract to open it
@@ -58,7 +58,7 @@ contract USDCAdapter is Initializable, AccessControlUpgradeable {
         address owner,
         uint256 _vaultId
     ) external isLive {
-        if (amount <= 0) {
+        if (amount == 0) {
             revert ZeroAmount("Adapter/amount-is-zero");
         }
         address vaultOwner = vaultContract.getVaultOwner(_vaultId);
@@ -112,7 +112,7 @@ contract xNGNAdapter is Initializable, AccessControlUpgradeable {
         address owner,
         uint256 _vaultId
     ) external isLive {
-        if (amount <= 0) {
+        if (amount == 0) {
             revert ZeroAmount("Adapter/amount-is-zero");
         }
         // calls the cleanse vault contrarct method
@@ -128,7 +128,7 @@ contract xNGNAdapter is Initializable, AccessControlUpgradeable {
         address owner,
         uint256 _vaultId
     ) external isLive {
-        if (amount <= 0) {
+        if (amount == 0) {
             revert ZeroAmount("Adapter/amount-is-zero");
         }
         address vaultOwner = vaultContract.getVaultOwner(_vaultId);

--- a/contracts/interface/IVault.sol
+++ b/contracts/interface/IVault.sol
@@ -7,30 +7,30 @@ interface IVault is IVaultSchema {
     function createVault(
         address owner,
         bytes32 _collateralName
-    ) external returns (uint);
+    ) external returns (uint256);
 
     function collateralizeVault(
         uint256 amount,
         address owner,
         uint256 _vaultId
-    ) external returns (uint, uint);
+    ) external returns (uint256, uint256);
 
     function withdrawStableToken(
-        uint _vaultId,
+        uint256 _vaultId,
         uint256 amount
     ) external returns (bool);
 
     function withdrawUnlockedCollateral(
-        uint _vaultId,
+        uint256 _vaultId,
         uint256 amount
     ) external returns (bool);
 
     function cleanseVault(
-        uint _vaultId,
+        uint256 _vaultId,
         uint256 amount
     ) external returns (bool);
 
-    function getVaultId() external view returns (uint);
+    function getVaultId() external view returns (uint256);
 
     function getVaultById(
         uint256 _vaultId
@@ -40,7 +40,7 @@ interface IVault is IVaultSchema {
 
     function getVaultsForOwner(
         address owner
-    ) external view returns (uint[] memory);
+    ) external view returns (uint256[] memory);
 
     function getCollateralData(
         bytes32 _collateralName
@@ -59,10 +59,12 @@ interface IVault is IVaultSchema {
         );
 
     function getCollateralDataByVaultId(
-        uint _vaultId
+        uint256 _vaultId
     ) external view returns (Collateral memory);
 
-    function getVaultCountForOwner(address owner) external view returns (uint);
+    function getVaultCountForOwner(
+        address owner
+    ) external view returns (uint256);
 
     function getAvailableStableToken(
         address owner

--- a/contracts/interface/IxNGN.sol
+++ b/contracts/interface/IxNGN.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.21;
 
 interface IxNGN {
-    function mint(address account, uint amount) external returns (bool);
+    function mint(address account, uint256 amount) external returns (bool);
 
-    function burn(address account, uint amount) external returns (bool);
+    function burn(address account, uint256 amount) external returns (bool);
 
     function permitToken(
         address owner,

--- a/contracts/ngn.sol
+++ b/contracts/ngn.sol
@@ -9,7 +9,6 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUp
 import "./helpers/ERC2771ContextUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-
 contract xNGN is
     Initializable,
     AccessControlUpgradeable,
@@ -46,7 +45,9 @@ contract xNGN is
      * @dev sets a minter role
      * @param account address for the minter role
      */
-    function setMinterRole(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setMinterRole(
+        address account
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _grantRole(MINTER_ROLE, account);
     }
 
@@ -55,7 +56,10 @@ contract xNGN is
      * @param account address to send the minted tokens to
      * @param amount amount of tokens to mint
      */
-    function mint(address account, uint256 amount) external onlyRole(MINTER_ROLE) returns (bool) {
+    function mint(
+        address account,
+        uint256 amount
+    ) external onlyRole(MINTER_ROLE) returns (bool) {
         if (live != 1) {
             revert NotLive("xNGN/not-live");
         }
@@ -68,11 +72,17 @@ contract xNGN is
      * @param account address to burn tokens from
      * @param amount amount of tokens to burn
      */
-    function burn(address account, uint256 amount) external onlyRole(MINTER_ROLE) returns (bool) {
+    function burn(
+        address account,
+        uint256 amount
+    ) external onlyRole(MINTER_ROLE) returns (bool) {
         if (live != 1) {
             revert NotLive("xNGN/not-live");
         }
-        if (account != msg.sender && allowance(account, msg.sender) != type(uint256).max) {
+        if (
+            account != msg.sender &&
+            allowance(account, msg.sender) != type(uint256).max
+        ) {
             if (allowance(account, msg.sender) < amount) {
                 revert NotLive("xNGN/not-live");
             }
@@ -84,9 +94,15 @@ contract xNGN is
     /**
      * @dev Approve by signature -- doesn't require gas
      */
-    function permitToken(address owner, address spender, uint256 value, uint256 expiry, uint8 v, bytes32 r, bytes32 s)
-        external
-    {
+    function permitToken(
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 expiry,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
         permit(owner, spender, value, expiry, v, r, s);
     }
 
@@ -103,7 +119,10 @@ contract xNGN is
      * @param tokenAddress address of the token to withdraw
      * @param account account to withdraw tokens to
      */
-    function withdrawToken(address tokenAddress, address account) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
+    function withdrawToken(
+        address tokenAddress,
+        address account
+    ) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
         IERC20 token = IERC20(tokenAddress);
         uint256 tokenBalance = token.balanceOf(address(this));
         token.transfer(account, tokenBalance);

--- a/contracts/ngn.sol
+++ b/contracts/ngn.sol
@@ -7,10 +7,8 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";
 import "./helpers/ERC2771ContextUpgradeable.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
-import "hardhat/console.sol";
 
 contract xNGN is
     Initializable,
@@ -24,7 +22,7 @@ contract xNGN is
 
     // --- ERC20 Data ---
     string public constant version = "1";
-    uint public live; // Active Flag
+    uint256 public live; // Active Flag
 
     // -- EVENTS --
     event Cage();
@@ -48,9 +46,7 @@ contract xNGN is
      * @dev sets a minter role
      * @param account address for the minter role
      */
-    function setMinterRole(
-        address account
-    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setMinterRole(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
         _grantRole(MINTER_ROLE, account);
     }
 
@@ -59,10 +55,7 @@ contract xNGN is
      * @param account address to send the minted tokens to
      * @param amount amount of tokens to mint
      */
-    function mint(
-        address account,
-        uint amount
-    ) external onlyRole(MINTER_ROLE) returns (bool) {
+    function mint(address account, uint256 amount) external onlyRole(MINTER_ROLE) returns (bool) {
         if (live != 1) {
             revert NotLive("xNGN/not-live");
         }
@@ -75,19 +68,12 @@ contract xNGN is
      * @param account address to burn tokens from
      * @param amount amount of tokens to burn
      */
-    function burn(
-        address account,
-        uint amount
-    ) external onlyRole(MINTER_ROLE) returns (bool) {
+    function burn(address account, uint256 amount) external onlyRole(MINTER_ROLE) returns (bool) {
         if (live != 1) {
             revert NotLive("xNGN/not-live");
         }
-        if (
-            account != msg.sender &&
-            allowance(account, msg.sender) != type(uint).max
-        ) {
+        if (account != msg.sender && allowance(account, msg.sender) != type(uint256).max) {
             if (allowance(account, msg.sender) < amount) {
-                console.log(allowance(msg.sender, account));
                 revert NotLive("xNGN/not-live");
             }
         }
@@ -98,15 +84,9 @@ contract xNGN is
     /**
      * @dev Approve by signature -- doesn't require gas
      */
-    function permitToken(
-        address owner,
-        address spender,
-        uint256 value,
-        uint256 expiry,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external {
+    function permitToken(address owner, address spender, uint256 value, uint256 expiry, uint8 v, bytes32 r, bytes32 s)
+        external
+    {
         permit(owner, spender, value, expiry, v, r, s);
     }
 
@@ -123,10 +103,7 @@ contract xNGN is
      * @param tokenAddress address of the token to withdraw
      * @param account account to withdraw tokens to
      */
-    function withdrawToken(
-        address tokenAddress,
-        address account
-    ) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
+    function withdrawToken(address tokenAddress, address account) public virtual onlyRole(DEFAULT_ADMIN_ROLE) {
         IERC20 token = IERC20(tokenAddress);
         uint256 tokenBalance = token.balanceOf(address(this));
         token.transfer(account, tokenBalance);

--- a/contracts/schema/IVaultSchema.sol
+++ b/contracts/schema/IVaultSchema.sol
@@ -24,8 +24,8 @@ interface IVaultSchema {
     }
 
     struct List {
-        uint prev;
-        uint next;
+        uint256 prev;
+        uint256 next;
     }
 
     enum VaultStateEnum {

--- a/contracts/vault.sol
+++ b/contracts/vault.sol
@@ -33,10 +33,21 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
     event VaultCreated(uint256 vaultId, address indexed owner);
     event CollateralAdded(bytes32 collateralName);
     event VaultCollateralized(
-        uint256 unlockedCollateral, uint256 availableStableToken, address indexed owner, uint256 vaultId
+        uint256 unlockedCollateral,
+        uint256 availableStableToken,
+        address indexed owner,
+        uint256 vaultId
     );
-    event StableTokenWithdrawn(uint256 amount, address indexed owner, uint256 vaultId);
-    event CollateralWithdrawn(uint256 amount, address indexed owner, uint256 vaultId);
+    event StableTokenWithdrawn(
+        uint256 amount,
+        address indexed owner,
+        uint256 vaultId
+    );
+    event CollateralWithdrawn(
+        uint256 amount,
+        address indexed owner,
+        uint256 vaultId
+    );
     event VaultCleansed(uint256 amount, address indexed owner, uint256 vaultId);
 
     // - Vault type --
@@ -63,7 +74,11 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
     }
 
     // -- UTILITY --
-    function scalePrecision(uint256 amount, uint256 fromDecimal, uint256 toDecimal) internal pure returns (uint256) {
+    function scalePrecision(
+        uint256 amount,
+        uint256 fromDecimal,
+        uint256 toDecimal
+    ) internal pure returns (uint256) {
         if (fromDecimal > toDecimal) {
             return amount / 10 ** (fromDecimal - toDecimal);
         } else if (fromDecimal < toDecimal) {
@@ -104,12 +119,11 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
         return true;
     }
 
-    function updateCollateralData(bytes32 _collateralName, bytes32 param, uint256 data)
-        external
-        isLive
-        onlyRole(DEFAULT_ADMIN_ROLE)
-        returns (bool)
-    {
+    function updateCollateralData(
+        bytes32 _collateralName,
+        bytes32 param,
+        uint256 data
+    ) external isLive onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
         Collateral storage _collateral = collateralMapping[_collateralName];
         if (param == "price") {
             _collateral.price = data;
@@ -137,7 +151,10 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
      * @param owner address that owns the vault
      * @param _collateralName name of the collateral tied to a vault
      */
-    function createVault(address owner, bytes32 _collateralName) external isLive returns (uint256) {
+    function createVault(
+        address owner,
+        bytes32 _collateralName
+    ) external isLive returns (uint256) {
         if (owner == address(0)) {
             revert ZeroAddress("CoreVault/owner address is zero ");
         }
@@ -183,18 +200,24 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
      * @param owner Owner of the vault
      * @param _vaultId ID of the vault to be collaterized
      */
-    function collateralizeVault(uint256 amount, address owner, uint256 _vaultId)
-        external
-        isLive
-        returns (uint256, uint256)
-    {
+    function collateralizeVault(
+        uint256 amount,
+        address owner,
+        uint256 _vaultId
+    ) external isLive returns (uint256, uint256) {
         Vault storage _vault = vaultMapping[_vaultId];
-        Collateral storage _collateral = collateralMapping[_vault.collateralName];
+        Collateral storage _collateral = collateralMapping[
+            _vault.collateralName
+        ];
 
         _vault.unlockedCollateral += amount;
         _collateral.TotalCollateralValue += amount;
 
-        uint256 expectedAmount = scalePrecision(amount, _collateral.collateralDecimal, stableToken.decimals());
+        uint256 expectedAmount = scalePrecision(
+            amount,
+            _collateral.collateralDecimal,
+            stableToken.decimals()
+        );
         /* Collateral price will be updated frequently from the Price module(this is a function of current price / liquidation ratio) and stored in the
          ** collateral struct for every given collateral.
          */
@@ -202,7 +225,12 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
 
         availableStableToken[owner] += debtAmount;
 
-        emit VaultCollateralized(_vault.unlockedCollateral, availableStableToken[owner], owner, _vaultId);
+        emit VaultCollateralized(
+            _vault.unlockedCollateral,
+            availableStableToken[owner],
+            owner,
+            _vaultId
+        );
         return (availableStableToken[owner], _vault.unlockedCollateral);
     }
 
@@ -211,13 +239,22 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
      * @param _vaultId ID of the vault tied to the user
      * @param amount amount of stableToken to be withdrawn
      */
-    function withdrawStableToken(uint256 _vaultId, uint256 amount) external isLive returns (bool) {
+    function withdrawStableToken(
+        uint256 _vaultId,
+        uint256 amount
+    ) external isLive returns (bool) {
         address _owner = ownerMapping[_vaultId];
         availableStableToken[_owner] -= amount;
         Vault storage _vault = vaultMapping[_vaultId];
-        Collateral storage _collateral = collateralMapping[_vault.collateralName];
+        Collateral storage _collateral = collateralMapping[
+            _vault.collateralName
+        ];
 
-        uint256 expectedCollateralAmount = scalePrecision(amount, stableToken.decimals(), _collateral.collateralDecimal);
+        uint256 expectedCollateralAmount = scalePrecision(
+            amount,
+            stableToken.decimals(),
+            _collateral.collateralDecimal
+        );
 
         uint256 collateralAmount = expectedCollateralAmount / _collateral.price;
 
@@ -241,9 +278,14 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
      * @param _vaultId ID of the vault tied to the user
      * @param amount amount of collateral to be withdrawn
      */
-    function withdrawUnlockedCollateral(uint256 _vaultId, uint256 amount) external isLive returns (bool) {
+    function withdrawUnlockedCollateral(
+        uint256 _vaultId,
+        uint256 amount
+    ) external isLive returns (bool) {
         Vault storage _vault = vaultMapping[_vaultId];
-        Collateral storage _collateral = collateralMapping[_vault.collateralName];
+        Collateral storage _collateral = collateralMapping[
+            _vault.collateralName
+        ];
 
         _vault.unlockedCollateral -= amount;
 
@@ -265,11 +307,20 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
      * @param _vaultId ID of the vault tied to the user
      * @param amount amount of stableToken to pay back
      */
-    function cleanseVault(uint256 _vaultId, uint256 amount) external isLive returns (bool) {
+    function cleanseVault(
+        uint256 _vaultId,
+        uint256 amount
+    ) external isLive returns (bool) {
         Vault storage _vault = vaultMapping[_vaultId];
-        Collateral storage _collateral = collateralMapping[_vault.collateralName];
+        Collateral storage _collateral = collateralMapping[
+            _vault.collateralName
+        ];
 
-        uint256 expectedAmount = scalePrecision(amount, stableToken.decimals(), _collateral.collateralDecimal);
+        uint256 expectedAmount = scalePrecision(
+            amount,
+            stableToken.decimals(),
+            _collateral.collateralDecimal
+        );
 
         uint256 collateralAmount = expectedAmount / _collateral.price;
 
@@ -297,7 +348,9 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
         return vaultId;
     }
 
-    function getVaultById(uint256 _vaultId) external view returns (Vault memory) {
+    function getVaultById(
+        uint256 _vaultId
+    ) external view returns (Vault memory) {
         Vault memory _vault = vaultMapping[_vaultId];
 
         return _vault;
@@ -308,10 +361,21 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
         return _owner;
     }
 
-    function getCollateralData(bytes32 _collateralName)
+    function getCollateralData(
+        bytes32 _collateralName
+    )
         external
         view
-        returns (uint256, uint256, uint256, uint256, uint256, uint256, uint256, uint256)
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        )
     {
         Collateral storage _collateral = collateralMapping[_collateralName];
 
@@ -327,11 +391,15 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
         );
     }
 
-    function getVaultCountForOwner(address owner) external view returns (uint256) {
+    function getVaultCountForOwner(
+        address owner
+    ) external view returns (uint256) {
         return vaultCountMapping[owner];
     }
 
-    function getVaultsForOwner(address owner) external view returns (uint256[] memory ids) {
+    function getVaultsForOwner(
+        address owner
+    ) external view returns (uint256[] memory ids) {
         uint256 count = _getVaultCountForOwner(owner);
         ids = new uint[](count);
 
@@ -346,11 +414,15 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
         }
     }
 
-    function getAvailableStableToken(address owner) external view returns (uint256) {
+    function getAvailableStableToken(
+        address owner
+    ) external view returns (uint256) {
         return availableStableToken[owner];
     }
 
-    function _getVaultCountForOwner(address owner) internal view returns (uint256) {
+    function _getVaultCountForOwner(
+        address owner
+    ) internal view returns (uint256) {
         return vaultCountMapping[owner];
     }
 

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -5,6 +5,7 @@ import USDCAbi from "./abis/usdc.json";
 
 describe("Onboard Vault", async () => {
   let adminAccount;
+  let adminAddress: string;
   let vaultContract: any;
   let xNGNContract: any;
   let usdcAdaptercontract: any;
@@ -14,6 +15,7 @@ describe("Onboard Vault", async () => {
   let usdcTokenContractWithSigner: any;
   let unlockedAddress = "0x51eDF02152EBfb338e03E30d65C15fBf06cc9ECC";
   let usdcAddress = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+  const collateraType = ethers.encodeBytes32String("USDC-A");
 
   async function impersonateAccount() {
     const signer = await hre.ethers.provider.getSigner(unlockedAddress);
@@ -24,7 +26,7 @@ describe("Onboard Vault", async () => {
       params: [unlockedAddress],
     });
 
-    usdcTokenContract = await new ethers.Contract(usdcAddress, USDCAbi, signer);
+    usdcTokenContract = new ethers.Contract(usdcAddress, USDCAbi, signer);
     usdcTokenContractWithSigner = usdcTokenContract.connect(signer);
 
     console.log(
@@ -74,12 +76,10 @@ describe("Onboard Vault", async () => {
     );
   }
 
-  const collateraType = ethers.encodeBytes32String("USDC-A");
-
-  [adminAccount] = await ethers.getSigners();
-  const adminAddress = adminAccount.address;
-
   before(async () => {
+    [adminAccount] = await ethers.getSigners();
+    adminAddress = adminAccount.address;
+
     // deploy xngn contract
     const xNGNToken = await ethers.getContractFactory("xNGN");
     xNGNContract = await upgrades.deployProxy(xNGNToken, [[adminAddress]], {


### PR DESCRIPTION
This pr:

- removes safe math lib since  uses solidity version >0.8.0, overflows are checked by default
- optimizes the vault contract
- test doesn't run on my machine, moved `ethers.getSigner()` from directly within the `describe` block and into an `it` block to enable it run