### PR TITLE
Implement Feed module

### DIFF
--- a/contracts/adapter.sol
+++ b/contracts/adapter.sol
@@ -41,16 +41,22 @@ contract USDCAdapter is Initializable, AccessControlUpgradeable {
         uint256 amount,
         address owner,
         uint256 _vaultId
-    ) external isLive {
+    ) external isLive returns (uint256, uint256) {
         if (amount <= 0) {
             revert ZeroAmount("Adapter/amount-is-zero");
         }
         // calls vault contract to open it
-        vaultContract.collateralizeVault(amount, owner, _vaultId);
+        (
+            uint256 availableStableToken,
+            uint256 unlockedCollateral
+        ) = vaultContract.collateralizeVault(amount, owner, _vaultId);
+
         // transfers collateral from user to adapter contract
         collateralContract.transferFrom(msg.sender, address(this), amount);
 
         emit USDCJoined(_vaultId, owner, amount);
+
+        return (availableStableToken, unlockedCollateral);
     }
 
     function exit(

--- a/contracts/feed.sol
+++ b/contracts/feed.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+//  ==========  External imports    ==========
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import "./interface/IMedian.sol";
+import "./interface/IVault.sol";
+
+contract Feed is Initializable, AccessControlUpgradeable {
+    IVault public vault;
+    uint256 public live;
+
+    // --- PRECISION ---
+    uint256 BASE_POINT = 100;
+    struct Collateral {
+        IMedian priceOracle;
+        uint256 liquidationRatio;
+    }
+
+    mapping(bytes32 => Collateral) public collaterals;
+
+    // -- ERRORS --
+    error NotLive(string error);
+    error ZeroAddress(string error);
+    error UnrecognizedParam(string error);
+
+    // --- Events ---
+    event Read(
+        bytes32 collateral,
+        uint256 price,
+        uint256 priceWithLiquidationRatio,
+        uint256 timestamp
+    );
+
+    function initialize(address vaultAddress) public initializer {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        vault = IVault(vaultAddress);
+        live = 1;
+    }
+
+    // modifier
+    modifier isLive() {
+        if (live != 1) {
+            revert NotLive("Feed/not-live");
+        }
+        _;
+    }
+
+    function setLiquidationRatio(
+        uint256 liquidationRatio,
+        bytes32 collateral
+    ) external isLive onlyRole(DEFAULT_ADMIN_ROLE) {
+        Collateral storage _collateral = collaterals[collateral];
+        _collateral.liquidationRatio = liquidationRatio;
+    }
+
+    function setPriceOracleContract(
+        address oracle,
+        bytes32 collateral
+    ) external isLive onlyRole(DEFAULT_ADMIN_ROLE) {
+        Collateral storage _collateral = collaterals[collateral];
+        _collateral.priceOracle = IMedian(oracle);
+    }
+
+    //Updates the price of a collateral in the accounting
+    function updatePrice(
+        bytes32 collateral
+    ) external isLive onlyRole(DEFAULT_ADMIN_ROLE) {
+        (uint256 timestamp, uint256 price) = collaterals[collateral]
+            .priceOracle
+            .read();
+
+        // get liquidation %
+        uint256 precisionValueofLiquidation = (collaterals[collateral]
+            .liquidationRatio * BASE_POINT) / 100;
+        uint256 priceWithLiquidation = price / precisionValueofLiquidation;
+
+        vault.updateCollateralData(collateral, "price", priceWithLiquidation);
+
+        emit Read(collateral, price, priceWithLiquidation, timestamp);
+    }
+}

--- a/contracts/interface/IAdapter.sol
+++ b/contracts/interface/IAdapter.sol
@@ -4,7 +4,11 @@ pragma solidity 0.8.21;
 interface IUSDCAdapter {
     function exit(uint256 amount, address owner, uint256 _vaultId) external;
 
-    function join(uint256 amount, address owner, uint256 _vaultId) external;
+    function join(
+        uint256 amount,
+        address owner,
+        uint256 _vaultId
+    ) external returns (uint256, uint256);
 }
 
 interface INGNXAdapter {

--- a/contracts/interface/IFeed.sol
+++ b/contracts/interface/IFeed.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+interface IFeed {
+    function updatePrice(bytes32 collateral) external;
+
+    function setLiquidationRatio(
+        uint256 liquidationRatio,
+        bytes32 collateral
+    ) external;
+
+    function setPriceOracleContract(
+        address oracle,
+        bytes32 collateral
+    ) external;
+}

--- a/contracts/interface/IMedian.sol
+++ b/contracts/interface/IMedian.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+interface IMedian {
+    // Updates the price
+    function update(
+        uint256[] calldata _prices,
+        uint64[] calldata _timestamps,
+        bytes[] calldata _signatures
+    ) external;
+
+    // Reads the price and the timestamp
+    function read() external view returns (uint256, uint256);
+
+    // Reads historical price data
+    function priceHistory(
+        uint256 index
+    ) external view returns (uint128, uint128);
+}

--- a/contracts/interface/IVault.sol
+++ b/contracts/interface/IVault.sol
@@ -13,7 +13,7 @@ interface IVault is IVaultSchema {
         uint256 amount,
         address owner,
         uint256 _vaultId
-    ) external returns (uint, uint);
+    ) external returns (uint256, uint256);
 
     function withdrawStableToken(
         uint _vaultId,

--- a/contracts/interface/IVault.sol
+++ b/contracts/interface/IVault.sol
@@ -30,6 +30,12 @@ interface IVault is IVaultSchema {
         uint256 amount
     ) external returns (bool);
 
+    function updateCollateralData(
+        bytes32 _collateralName,
+        bytes32 param,
+        uint256 data
+    ) external returns (bool);
+
     function getVaultId() external view returns (uint256);
 
     function getVaultById(

--- a/contracts/vault.sol
+++ b/contracts/vault.sol
@@ -197,7 +197,7 @@ contract CoreVault is Initializable, AccessControlUpgradeable, IVaultSchema {
         uint256 amount,
         address owner,
         uint256 _vaultId
-    ) external isLive returns (uint, uint) {
+    ) external isLive returns (uint256, uint256) {
         Vault storage _vault = vaultMapping[_vaultId];
         Collateral storage _collateral = collateralMapping[
             _vault.collateralName

--- a/test/core.test.ts
+++ b/test/core.test.ts
@@ -175,13 +175,15 @@ describe("Onboard Vault", async () => {
     console.log(allowance, "allowance for contract");
     const res = await vaultContract.getVaultId();
 
-    await expect(
-      usdcAdaptercontract.join(
-        "100000000",
-        adminAddress,
-        BigInt(res).toString()
-      )
-    ).to.emit(usdcAdaptercontract, "USDCJoined");
+    const join = await usdcAdaptercontract.join(
+      "100000000",
+      adminAddress,
+      BigInt(res).toString()
+    );
+    const res2 = await join.wait();
+
+    console.log(res2.logs, "collateralize vault");
+
     const vault = await vaultContract.getVaultById(BigInt(res).toString());
     console.log(vault, "vault data");
 
@@ -331,7 +333,7 @@ describe("Onboard Vault", async () => {
     expect(Number(balanceAfterWithdrawal)).to.be.greaterThan(
       Number(balanceBeforeWithdrawal)
     );
-    const vault = await vaultContract.getVaultById(BigInt(res).toString());
-    console.log(vault, "vault data");
+    const vault = await vaultContract.getVaultsForOwner(adminAddress);
+    console.log(vault, "vaultids for owner");
   });
 });


### PR DESCRIPTION
The feed contract is responsible for reading and updating the price of collaterals from the oracle. It also puts in place a security module that ensures that the new value prices propagated are not updated until after a specified delay period has been passed. This contract reads the price from a median.sol contract. 

The feed contract calls the median contract to get new price, calculate price base on liquidation ratio and updates price for the particular collateral