### PR TITLE
support createCollateralType json parameters in config json and scripts

### DIFF
--- a/deployConfigs/localnet.json
+++ b/deployConfigs/localnet.json
@@ -1,3 +1,13 @@
 {
-  "baseRate": 317097919
+  "baseRate": "317097919",
+  "collaterals": {
+    "USDC": {
+      "collateralAddress": "",
+      "collateralRate": "475646879",
+      "liquidationThreshold": "750000000000000000",
+      "liquidationBonus": "100000000000000000",
+      "debtCeiling": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "collateralFloorPerPosition": "0"
+    }
+  }
 }

--- a/deployConfigs/testnet.base.json
+++ b/deployConfigs/testnet.base.json
@@ -1,9 +1,13 @@
 {
-  "baseRate": 317097919,
-},
-"collaterals": {
-  "USDC": {
-    "colllateral_rate": "",
-    "collateral_address": ""
+  "baseRate": "317097919",
+  "collaterals": {
+    "USDC": {
+      "collateralAddress": "",
+      "colllateralRate": "475646879",
+      "liquidationThreshold": "750000000000000000",
+      "liquidationBonus": "100000000000000000",
+      "debtCeiling": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+      "collateralFloorPerPosition": "0"
+    }
   }
 }

--- a/script/base.s.sol
+++ b/script/base.s.sol
@@ -55,7 +55,7 @@ abstract contract BaseScript is Script {
         vm.stopBroadcast();
     }
 
-    function getDeployJson() internal view returns (string memory json) {
+    function getDeployConfigJson() internal view returns (string memory json) {
         if (currenctChain == Chains.BaseTestnet) {
             json = vm.readFile(string.concat(vm.projectRoot(), "/deployConfigs/testnet.base.json"));
         } else {

--- a/script/deploy.s.sol
+++ b/script/deploy.s.sol
@@ -13,19 +13,19 @@ contract DeployScript is BaseScript {
     using stdJson for string;
 
     function run() external broadcast returns (Currency xNGN, Vault vault, Feed feed) {
-        uint256 baseRate = getDeployJson().readUint(".baseRate");
+        string memory deployConfigJson = getDeployConfigJson();
+        uint256 baseRate = deployConfigJson.readUint(".baseRate");
         xNGN = new Currency("xNGN", "xNGN");
         vault = new Vault(xNGN,  baseRate);
         feed = new Feed(vault);
 
-        ERC20 usdc = getOrCreateUsdc();
         vault.createCollateralType({
-            _collateralToken: usdc,
-            _rate: 475646879, // 1.5% per annum (in per second format)
-            _liquidationThreshold: 0.75e18, // 75% liquidation ratio
-            _liquidationBonus: 0.1e18, // 10% liquidation bonus
-            _debtCeiling: type(uint256).max, // no max cap
-            _collateralFloorPerPosition: 0 // no min collateral
+            _collateralToken: getOrCreateUsdc(),
+            _rate: deployConfigJson.readUint(".collaterals.USDC.collateralRate"),
+            _liquidationThreshold: deployConfigJson.readUint(".collaterals.USDC.liquidationThreshold"),
+            _liquidationBonus: deployConfigJson.readUint(".collaterals.USDC.liquidationBonus"),
+            _debtCeiling: deployConfigJson.readUint(".collaterals.USDC.debtCeiling"),
+            _collateralFloorPerPosition: deployConfigJson.readUint(".collaterals.USDC.collateralFloorPerPosition")
         });
     }
 
@@ -33,7 +33,7 @@ contract DeployScript is BaseScript {
         if (currenctChain == Chains.Localnet) {
             usdc = ERC20(address(new ERC20Token("Circle USD", "USDC")));
         } else {
-            usdc = ERC20(getDeployJson().readAddress(".usdc"));
+            usdc = ERC20(getDeployConfigJson().readAddress(".collaterals.USDC/collateralAddress"));
         }
     }
 }


### PR DESCRIPTION
- This pr adds support for parameters of `create collateral type` to be read from a json deploy config file