### PR TITLE
add brief explainer for deploy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ To run deploy the deploy script, (be sure to have the parameters in `./deployPar
 ```zsh
 forge script script/deploy.s.sol:DeployScript --fork-url http://localhost:8545 --broadcast
 ```
+
+## Deploy Config
+
+Meaning of parameters of the deploy configs
+
+- baseRate: The base rate of the protocol, should be the per second rate, e.g 1.5% would be `((uint256(1.5e18) / uint256(100)) / uint256(365 days)`, i.e `475646879`.
+- collaterals: collateral types
+  - collateralAddress: contract address of the given collateral on the given chain.
+  - collateralRate: The collateral rate of the given collateral on the given chain, calculated same as baseRate.
+  - liquidationThreshold: liquidation threshold of the given collateral, denominated in wad, where `1e18 == 100%` and `0.5e18 == 50%`.
+  - liquidationBonus: liquidation bonus of the given collateral, denominated same as liquidationThreshold.
+  - debtCeiling: debt ceiling of the currency for the given collateral.
+  - collateralFloorPerPosition: minimum amount of collateral allowed to borrow against.

--- a/deployConfigs/localnet.json
+++ b/deployConfigs/localnet.json
@@ -1,4 +1,5 @@
 {
+  "name": "Local chain deployment config",
   "baseRate": "317097919",
   "collaterals": {
     "USDC": {

--- a/deployConfigs/testnet.base.json
+++ b/deployConfigs/testnet.base.json
@@ -1,5 +1,5 @@
 {
-  "name": "Base Testnet Deployment Config"
+  "name": "Base Testnet Deployment Config",
   "baseRate": "317097919",
   "collaterals": {
     "USDC": {


### PR DESCRIPTION
- This adds a brief explainer in the README on the expected contents of the deploy configs, also updates the name of the localnet config file